### PR TITLE
Add an action to summarise events for a metric

### DIFF
--- a/analysis/get_event_summary.py
+++ b/analysis/get_event_summary.py
@@ -1,0 +1,48 @@
+import re
+from pathlib import Path
+
+import pandas
+
+INPUT_FILE_REGEX = re.compile(r"input_(?P<date>\d{4}-\d{2}-\d{2})\.csv")
+DATE_FORMAT = "%Y-%m-%d"
+OUTPUT_DIR = Path("output")
+
+MEASURE_COL = "hba1c"
+MEASURE_EVENT_CODE_COL = "hba1c_event_code"
+VALUE_COLS = [MEASURE_COL, MEASURE_EVENT_CODE_COL]
+INDEX_COLS = ["patient_id", "date"]
+
+
+def read_file(f_path):
+    date_str = re.match(INPUT_FILE_REGEX, f_path.name).group("date")
+    date_timestamp = pandas.to_datetime(date_str, format=DATE_FORMAT)
+    return pandas.read_csv(f_path).assign(date=date_timestamp)
+
+
+def get_records():
+    return (
+        pandas.concat(
+            (
+                read_file(x)
+                for x in OUTPUT_DIR.iterdir()
+                if re.match(INPUT_FILE_REGEX, x.name) is not None
+            ),
+            ignore_index=True,
+        )
+        .set_index(INDEX_COLS)
+        .loc[:, VALUE_COLS]
+    )
+
+
+def get_counts(records):
+    return records.loc[:, MEASURE_COL].groupby(INDEX_COLS).count()
+
+
+def write_summary(counts):
+    counts.describe().to_csv(OUTPUT_DIR / f"{MEASURE_COL}_event_summary.csv")
+
+
+if __name__ == "__main__":
+    records = get_records()
+    counts = get_counts(records)
+    write_summary(counts)

--- a/project.yaml
+++ b/project.yaml
@@ -59,4 +59,9 @@ actions:
   #       notebook: output/sentinel_measures_by_practice.html
   #       csvs: output/*_check.csv
 
-  
+  get_event_summary:
+    run: python:latest python analysis/get_event_summary.py
+    needs: [generate_study_population]
+    outputs:
+      moderately_sensitive:
+        text: output/*_event_summary.csv


### PR DESCRIPTION
At present, we summarise the number of events for a metric per patient per day. We don't do anything fancy, because I'm not sure:

1. that multiple events for a metric per patient per day is an issue (🤞🏻 it's not!)
2. if it is, then whether reporting the events themselves would disclose too much

I've tried to make *analysis/get_event_summary.py* straightforward to refactor to use a different measure, should we need to. (Or, alternatively, all measures.)