### PR TITLE
Refactor add percentiles

### DIFF
--- a/tests/test_notebooks_utilities.py
+++ b/tests/test_notebooks_utilities.py
@@ -186,18 +186,18 @@ def test_get_number_patients(tmp_path):
 
 
 @pytest.mark.parametrize(
-    "show_outer_percentiles,num_rows",
+    "has_outer_percentiles,num_rows",
     [
         (True, 54),  # Fifteen percentiles for two dates
         (False, 18),  # Nine deciles for two dates
     ],
 )
-def test_add_percentiles(measure_table, show_outer_percentiles, num_rows):
-    obs = utilities.add_percentiles(
+def test_compute_deciles(measure_table, has_outer_percentiles, num_rows):
+    obs = utilities.compute_deciles(
         measure_table,
         "date",
         "value",
-        show_outer_percentiles=show_outer_percentiles,
+        has_outer_percentiles=has_outer_percentiles,
     )
     # We expect Pandas to check that it computes deciles correctly,
     # leaving us to check the shape and the type of the data.


### PR DESCRIPTION
The final commit is the most important. Changes:

* Renamed function (it doesn't add percentiles; the output data frame has a different shape to the input data frame)
* Renamed parameters
* Simplified generation of quantiles
* Avoided calling rename (and remembering a default series name) by passing a series to `.quantile`
* Updated function and parameter names in the test (but not the behaviour of the test)

There are more changes here in fewer commits than previously, however the document/test/refactor loop is the same.

I'm not sure whether you use a *REPL* (Read Evaluate Print Loop), or open a shell like `ipython` to execute code. If you do, then you can use a pytest fixture like this:

```python
from tests import test_notebooks_utilities
measure_table = test_notebooks_utilities.measure_table.__wrapped__()
```

You can then use this to test `compute_deciles` like this:

```python
from notebooks import utilities
utilities.compute_deciles(measure_table, "date", "value")
```