### PR TITLE
Update codes tables

### DIFF
--- a/analysis/utilities.py
+++ b/analysis/utilities.py
@@ -144,7 +144,6 @@ def create_child_table(
         # give more logical column ordering
         event_counts = event_counts.loc[:, ["code", "Description", "Proportion of codes (%)"]]
     
-    event_counts.rename(columns = {"code": "Code"}, inplace=True)
 
     # return top n rows
     return event_counts.head(5)


### PR DESCRIPTION
This removes the event counts columns from the codes tables and replaces with a single proportion column. This column is suppressed if the number of codes not in the top 5 codes used is <=5 (which is unlikely)